### PR TITLE
Add additional checks during spidertron deserialization

### DIFF
--- a/scripts/spidertron_lib.lua
+++ b/scripts/spidertron_lib.lua
@@ -270,7 +270,7 @@ function spidertron_lib.deserialise_spidertron(spidertron, serialised_data, tran
 
   -- Copy across fuel, remaining_burning_fuel, etc (for modded spidertrons that use fuel)
   local burner = serialised_data.burner
-  if burner then
+  if burner and spidertron.burner then
     deserialise_burner(spidertron.burner, burner)
   end
 
@@ -287,27 +287,30 @@ function spidertron_lib.deserialise_spidertron(spidertron, serialised_data, tran
   local spidertron_grid = spidertron.grid
   if previous_grid_contents then
     for _, equipment in pairs(previous_grid_contents) do
-      if spidertron_grid then
-        local placed_equipment = spidertron_grid.put( {name=equipment.name, position=equipment.position} )
-        if placed_equipment then
-          if equipment.energy then placed_equipment.energy = equipment.energy end
-          if equipment.shield and equipment.shield > 0 then placed_equipment.shield = equipment.shield end
-          if equipment.burner and equipment.burner.serialised_burner then
-            -- Extra check for .serialised_burner to differentiate with legacy version below
-            deserialise_burner(placed_equipment.burner, equipment.burner)
-          elseif equipment.burner then
-            -- Legacy alternative
-            copy_inventory(equipment.burner_inventory, placed_equipment.burner.inventory)
-            copy_inventory(equipment.burner_burnt_result_inventory, placed_equipment.burner.burnt_result_inventory)
-            if equipment.heat then placed_equipment.burner.heat = equipment.burner_heat end
-            placed_equipment.burner.currently_burning = equipment.burner_currently_burning
-            placed_equipment.burner.remaining_burning_fuel = equipment.burner_remaining_burning_fuel
+      if game.equipment_prototypes[equipment.name] then
+        -- Only attempt deserialization if equipment prototype still exists
+        if spidertron_grid then
+          local placed_equipment = spidertron_grid.put( {name=equipment.name, position=equipment.position} )
+          if placed_equipment then
+            if equipment.energy then placed_equipment.energy = equipment.energy end
+            if equipment.shield and equipment.shield > 0 then placed_equipment.shield = equipment.shield end
+            if equipment.burner and equipment.burner.serialised_burner and placed_equipment.burner then
+              -- Extra check for .serialised_burner to differentiate with legacy version below
+              deserialise_burner(placed_equipment.burner, equipment.burner)
+            elseif equipment.burner and placed_equipment.burner then
+              -- Legacy alternative
+              copy_inventory(equipment.burner_inventory, placed_equipment.burner.inventory)
+              copy_inventory(equipment.burner_burnt_result_inventory, placed_equipment.burner.burnt_result_inventory)
+              if equipment.heat then placed_equipment.burner.heat = equipment.burner_heat end
+              placed_equipment.burner.currently_burning = equipment.burner_currently_burning
+              placed_equipment.burner.remaining_burning_fuel = equipment.burner_remaining_burning_fuel
+            end
+          else  -- No space in the grid because we have moved to a smaller grid
+            spidertron.surface.spill_item_stack(spidertron.position, {name=equipment.name})
           end
-        else  -- No space in the grid because we have moved to a smaller grid
+        else   -- No space in the grid because the grid has gone entirely
           spidertron.surface.spill_item_stack(spidertron.position, {name=equipment.name})
         end
-      else   -- No space in the grid because the grid has gone entirely
-        spidertron.surface.spill_item_stack(spidertron.position, {name=equipment.name})
       end
     end
   end


### PR DESCRIPTION
Hello!

I ran across a possible crash during deserialization when a mod is removed and some equipment and burners no longer exist, while updating [Space Spidertron](https://mods.factorio.com/mod/space-spidertron). I opted to simply ignore it when it no longer exist, because there's not really anything else you can do.

Thought I'd push it back upstream since my mod won't be possible without your amazing library. It's super easy to use and just works. So thanks again!